### PR TITLE
Fix 1.9 compatibility issue

### DIFF
--- a/lib/gmail-britta.rb
+++ b/lib/gmail-britta.rb
@@ -170,7 +170,7 @@ ATOM
 
     def log_definition
       $log.debug  "Filter: #{self}"
-      Filter.single_write_accessors.each do |name|
+      Filter.single_write_accessors.keys.each do |name|
         val = instance_variable_get(Filter.ivar_name(name))
         $log.debug "  #{name}: #{val}" if val
       end


### PR DESCRIPTION
I assume this is actually 1.9 being more strict about the arity of blocks than 1.8 was, but in any case, this seems to be sufficient to fix things.
