### PR TITLE
Split out XML app:property generation

### DIFF
--- a/lib/gmail-britta/filter.rb
+++ b/lib/gmail-britta/filter.rb
@@ -144,12 +144,12 @@ module GmailBritta
   %title Mail Filter
   %content
 #{generate_haml_properties 1}
-")
+", :attr_wrapper => '"')
       engine.render(self)
     end
 
     def generate_xml_properties
-      engine = Haml::Engine.new(generate_haml_properties)
+      engine = Haml::Engine.new(generate_haml_properties, :attr_wrapper => '"')
       engine.render(self)
     end
 

--- a/lib/gmail-britta/filter.rb
+++ b/lib/gmail-britta/filter.rb
@@ -137,16 +137,19 @@ module GmailBritta
     # Return the filter's value as XML text.
     # @return [String] the Atom XML representation of this filter
     def generate_xml
-      engine = Haml::Engine.new(<<-ATOM)
+      properties = generate_xml_properties
+      engine = Haml::Engine.new("
 %entry
   %category{:term => 'filter'}
   %title Mail Filter
   %content
-  - self.class.single_write_accessors.keys.each do |name|
-    - gmail_name = self.class.single_write_accessors[name]
-    - if value = self.send("output_\#{name}".intern)
-      %apps:property{:name => gmail_name, :value => value.to_s}
-ATOM
+#{generate_haml_properties 1}
+")
+      engine.render(self)
+    end
+
+    def generate_xml_properties
+      engine = Haml::Engine.new(generate_haml_properties)
       engine.render(self)
     end
 
@@ -232,6 +235,21 @@ ATOM
     # Return the list of emails that the filterset has configured as "me".
     def me
       @britta.me
+    end
+
+    private
+
+    def generate_haml_properties(indent=0)
+      properties =
+"- self.class.single_write_accessors.keys.each do |name|
+  - gmail_name = self.class.single_write_accessors[name]
+  - if value = self.send(\"output_\#{name}\".intern)
+    %apps:property{:name => gmail_name, :value => value.to_s}"
+      if (indent)
+        indent_sp = ' '*indent*2
+        properties = indent_sp + properties.split("\n").join("\n" + indent_sp)
+      end
+      properties
     end
   end
 end


### PR DESCRIPTION
The GApps API allows filter creation following the same <app:property /> rules as you use here. Split them out so that it's easier to reuse your rules for API-based creation.