### PR TITLE
Update filter chaining to be more consistent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :development do
   gem "bundler", ">= 1.2.0"
   gem "minitest"
   gem "nokogiri", "~> 1.8.1"
+  gem "pry"
 end
 
 group :doc do

--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,5 @@ end
 group :release do
   gem "juwelier"
 end
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .
+  specs:
+    gmail-britta (0.1.7)
+      haml (~> 3.1.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -69,6 +75,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (>= 1.2.0)
+  gmail-britta!
   haml (~> 3.1.6)
   juwelier
   minitest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     builder (3.2.3)
+    coderay (1.1.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     docile (1.1.5)
@@ -41,6 +42,7 @@ GEM
     jwt (1.5.6)
     kamelcase (0.0.1)
       semver2 (~> 3)
+    method_source (0.9.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     multi_json (1.12.2)
@@ -54,6 +56,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     psych (3.0.2)
     public_suffix (3.0.1)
     rack (2.0.3)
@@ -80,6 +85,7 @@ DEPENDENCIES
   juwelier
   minitest
   nokogiri (~> 1.8.1)
+  pry
   rake (>= 0.9.2)
   rdoc (~> 3.12)
   redcarpet (~> 2.2.2)

--- a/lib/gmail-britta/chaining_filter.rb
+++ b/lib/gmail-britta/chaining_filter.rb
@@ -52,6 +52,12 @@ module GmailBritta
       @subject += invert(load_array(:subject, criteria))
       @has_not += deep_invert(load_array(:has_not, criteria), load_array(:has, criteria))
 
+      if criteria.has_key?(:has_attachment)
+        has_attachment = criteria.delete(:has_attachment)
+        unless self.instance_variable_defined?("@has_attachment")
+          @has_attachment = !has_attachment
+        end
+      end
       if criteria.keys.length > 0
         raise("Did not invert criteria #{criteria.keys} - this is likely a bug in gmail-britta")
       end

--- a/lib/gmail-britta/filter.rb
+++ b/lib/gmail-britta/filter.rb
@@ -203,6 +203,7 @@ module GmailBritta
       @to = []
       @has = []
       @has_not = []
+      @subject = []
     end
 
     # Return the filter's value as XML text.

--- a/lib/gmail-britta/filter.rb
+++ b/lib/gmail-britta/filter.rb
@@ -9,7 +9,64 @@ module GmailBritta
   class Filter
     include SingleWriteAccessors
 
-    # @!group Methods for use in a filter definition block
+    # @!group Criteria for matching messages in filter blocks
+    # @!method has(conditions)
+    # @return [void]
+    # Defines the positive conditions for the filter to match.
+    # @overload has([conditions])
+    #   Conditions ANDed together that an incoming email must match.
+    #   @param [Array<conditions>] conditions a list of gmail search terms, all of which must match
+    # @overload has({:or => [conditions]})
+    #   Conditions ORed together for the filter to match
+    #   @param [{:or => conditions}] conditions a hash of the form `{:or => [condition1, condition2]}` - either of these conditions must match to match the filter.
+    define_criteria :has, 'hasTheWord' do |list|
+      emit_filter_spec(list)
+    end
+
+    # @!method from(conditions)
+    # @return [void]
+    # Defines the positive conditions for the filter to match.
+    # Uses: <apps:property name='from' value='postman@usps.gov'></apps:property>
+    # Instead of: <apps:property name='hasTheWord' value='from:postman@usps.gov'></apps:property>
+    define_criteria :from, 'from' do |list|
+      emit_filter_spec(list)
+    end
+
+    # @!method to(conditions)
+    # @return [void]
+    # Defines the positive conditions for the filter to match.
+    # Uses: <apps:property name='to' value='postman@usps.gov'></apps:property>
+    # Instead of: <apps:property name='hasTheWord' value='to:postman@usps.gov'></apps:property>
+    define_criteria :to, 'to' do |list|
+      emit_filter_spec(list)
+    end
+
+    # @!method subject(conditions)
+    # @return [void]
+    # Defines the positive conditions for the filter to match.
+    # @overload subject([conditions])
+    #   Conditions ANDed together that an incoming email must match.
+    #   @param [Array<conditions>] conditions a list of gmail search terms, all of which must match
+    # @overload subject({:or => [conditions]})
+    #   Conditions ORed together for the filter to match
+    #   @param [{:or => conditions}] conditions a hash of the form `{:or => [condition1, condition2]}` - either of these conditions must match to match the filter.
+    define_criteria :subject, 'subject' do |list|
+      emit_filter_spec(list)
+    end
+
+    # @!method has_not(conditions)
+    # @return [void]
+    # Defines the negative conditions that must not match for the filter to be allowed to match.
+    define_criteria :has_not, 'doesNotHaveTheWord' do |list|
+      emit_filter_spec(list)
+    end
+
+    # Filter for messages that have an attachment
+    # @macro bool_dsl_method
+    define_criteria :has_attachment, 'hasAttachment'
+    # @!endgroup
+
+    # @!group Actions to take on messages in filter blocks
     # Archive the message.
     # @!macro [new] bool_dsl_method
     #   @return [void]
@@ -72,61 +129,6 @@ module GmailBritta
     # @!method forward_to(email)
     # @param [String] email an email address to forward the message to
     single_write_accessor :forward_to, 'forwardTo'
-
-    # @!method has(conditions)
-    # @return [void]
-    # Defines the positive conditions for the filter to match.
-    # @overload has([conditions])
-    #   Conditions ANDed together that an incoming email must match.
-    #   @param [Array<conditions>] conditions a list of gmail search terms, all of which must match
-    # @overload has({:or => [conditions]})
-    #   Conditions ORed together for the filter to match
-    #   @param [{:or => conditions}] conditions a hash of the form `{:or => [condition1, condition2]}` - either of these conditions must match to match the filter.
-    single_write_accessor :has, 'hasTheWord' do |list|
-      emit_filter_spec(list)
-    end
-
-    # @!method from(conditions)
-    # @return [void]
-    # Defines the positive conditions for the filter to match.
-    # Uses: <apps:property name='from' value='postman@usps.gov'></apps:property>
-    # Instead of: <apps:property name='hasTheWord' value='from:postman@usps.gov'></apps:property>
-    single_write_accessor :from, 'from' do |list|
-      emit_filter_spec(list)
-    end
-
-    # @!method to(conditions)
-    # @return [void]
-    # Defines the positive conditions for the filter to match.
-    # Uses: <apps:property name='to' value='postman@usps.gov'></apps:property>
-    # Instead of: <apps:property name='hasTheWord' value='to:postman@usps.gov'></apps:property>
-    single_write_accessor :to, 'to' do |list|
-      emit_filter_spec(list)
-    end
-
-    # @!method subject(conditions)
-    # @return [void]
-    # Defines the positive conditions for the filter to match.
-    # @overload subject([conditions])
-    #   Conditions ANDed together that an incoming email must match.
-    #   @param [Array<conditions>] conditions a list of gmail search terms, all of which must match
-    # @overload subject({:or => [conditions]})
-    #   Conditions ORed together for the filter to match
-    #   @param [{:or => conditions}] conditions a hash of the form `{:or => [condition1, condition2]}` - either of these conditions must match to match the filter.
-    single_write_accessor :subject, 'subject' do |list|
-      emit_filter_spec(list)
-    end
-
-    # @!method has_not(conditions)
-    # @return [void]
-    # Defines the negative conditions that must not match for the filter to be allowed to match.
-    single_write_accessor :has_not, 'doesNotHaveTheWord' do |list|
-      emit_filter_spec(list)
-    end
-
-    # Filter for messages that have an attachment
-    # @macro bool_dsl_method
-    single_write_boolean_accessor :has_attachment, 'hasAttachment'
     # @!endgroup
 
     #@!group Filter chaining
@@ -134,6 +136,16 @@ module GmailBritta
       filter = type.new(self).perform(&block)
       filter.log_definition
       filter
+    end
+
+    def criteria
+      self.class.single_write_criteria.keys.reduce({}) do |res, name|
+        ivar = "@#{name.to_s}"
+        if instance_variable_defined?(ivar)
+          res[name] = instance_variable_get(ivar)
+        end
+        res
+      end
     end
 
     # Register and return a new filter that matches only if this

--- a/lib/gmail-britta/filter.rb
+++ b/lib/gmail-britta/filter.rb
@@ -63,7 +63,7 @@ module GmailBritta
 
     # Filter for messages that have an attachment
     # @macro bool_dsl_method
-    define_criteria :has_attachment, 'hasAttachment'
+    define_boolean_criteria :has_attachment, 'hasAttachment'
     # @!endgroup
 
     # @!group Actions to take on messages in filter blocks
@@ -301,7 +301,8 @@ module GmailBritta
       properties =
 "- self.class.single_write_accessors.keys.each do |name|
   - gmail_name = self.class.single_write_accessors[name]
-  - if value = self.send(\"output_\#{name}\".intern)
+  - if self.send(\"defined_\#{name}?\".intern)
+    - value = self.send(\"output_\#{name}\".intern)
     %apps:property{:name => gmail_name, :value => value.to_s}"
       if (indent)
         indent_sp = ' '*indent*2

--- a/lib/gmail-britta/single_write_accessors.rb
+++ b/lib/gmail-britta/single_write_accessors.rb
@@ -15,6 +15,16 @@ module GmailBritta
         super_accessors.merge(direct_single_write_accessors)
       end
 
+      # @return [Array<Symbol>] the criteria single write accessors
+      #   defined on this class and every superclass.
+      def single_write_criteria
+        super_accessors = {}
+        if self.superclass.respond_to?(:single_write_criteria)
+          super_accessors = self.superclass.single_write_criteria
+        end
+        super_accessors.merge(direct_single_write_criteria)
+      end
+
       # Defines a string-typed filter accessor DSL method.  Generates
       # the `[name]`, `get_[name]` and `output_[name]` methods.
       # @param name [Symbol] the name of the accessor method
@@ -37,6 +47,14 @@ module GmailBritta
         else
           output(name, ivar)
         end
+      end
+
+      # Defines a string-typed accessor DSL filter criteria
+      # method. This is a convenience method to more easily allow us
+      # to merge filters for chaining.
+      def define_criteria(name, gmail_name, &block)
+        direct_single_write_criteria[name] = gmail_name
+        single_write_accessor(name, gmail_name, &block)
       end
 
       # Defines a boolean-typed filter accessor DSL method. If the
@@ -81,6 +99,10 @@ module GmailBritta
 
       def direct_single_write_accessors
         @direct_single_write_accessors ||= {}
+      end
+
+      def direct_single_write_criteria
+        @direct_single_write_criteria ||= {}
       end
     end
 

--- a/lib/gmail-britta/single_write_accessors.rb
+++ b/lib/gmail-britta/single_write_accessors.rb
@@ -40,6 +40,7 @@ module GmailBritta
           instance_variable_set(ivar, words)
         end
         get(name, ivar)
+        string_defined(name, ivar)
         if block_given?
           define_method("output_#{name}") do
             instance_variable_get(ivar) && block.call(instance_variable_get(ivar)) unless instance_variable_get(ivar) == []
@@ -55,6 +56,12 @@ module GmailBritta
       def define_criteria(name, gmail_name, &block)
         direct_single_write_criteria[name] = gmail_name
         single_write_accessor(name, gmail_name, &block)
+      end
+
+      # Defines a boolean-typed accessor DSL filter criteria method.
+      def define_boolean_criteria(name, gmail_name, &block)
+        direct_single_write_criteria[name] = gmail_name
+        single_write_boolean_accessor(name, gmail_name, &block)
       end
 
       # Defines a boolean-typed filter accessor DSL method. If the
@@ -77,6 +84,7 @@ module GmailBritta
         end
         get(name, ivar)
         output(name, ivar)
+        boolean_defined(name, ivar)
       end
 
 
@@ -94,6 +102,18 @@ module GmailBritta
       def output(name, ivar)
         define_method("output_#{name}") do
           instance_variable_get(ivar)
+        end
+      end
+
+      def string_defined(name, ivar)
+        define_method("defined_#{name}?") do
+          !self.send("output_#{name}").nil?
+        end
+      end
+
+      def boolean_defined(name, ivar)
+        define_method("defined_#{name}?") do
+          instance_variable_defined?(ivar)
         end
       end
 

--- a/test/test_gmail-britta.rb
+++ b/test/test_gmail-britta.rb
@@ -286,8 +286,18 @@ describe GmailBritta do
       filter_text = filters.xpath('//apps:property[@name="subject"]', ns).first['value']
       assert_equal('SPAM OR HAM', filter_text)
     end
+  end
 
-
+  it 'only emits boolean criteria if set' do
+    fs = GmailBritta.filterset do
+      filter {
+        subject 'SPAM: '
+        label 'important'
+      }
+    end
+    filters = dom(fs)
+    criteria = filters.xpath('//apps:property[@name="hasAttachment"]', ns)
+    assert_equal(0, criteria.length, "Should not have generated hasAttachment criteria")
   end
 
   it "groups `has` criteria with spaces" do


### PR DESCRIPTION
This PR contains some long-overdue work on filter chaining to make it more consistent & able to handle more criteria:

* Negative and positive filter chaining now both use the same set of criteria (all of the one supported by gmail-britta).
  
* Upconvert implicitly-arrayed criteria when chaining filters: This fixes #11 (looong overdue on its own)

* Adds a bunch of tests around chaining.